### PR TITLE
catch timeout errors in http retry utils

### DIFF
--- a/discord_bot/cogs/markov.py
+++ b/discord_bot/cogs/markov.py
@@ -160,7 +160,7 @@ class Markov(CogHelper):
         while not self.bot.is_closed():
             try:
                 await self.markov_message_check()
-            except DiscordServerError as e:
+            except (DiscordServerError, TimeoutError) as e:
                 self.logger.warning(f'Markov :: Loop hit discord server exception, retrying {str(e)}')
                 await sleep(self.loop_sleep_interval)
                 continue

--- a/discord_bot/utils.py
+++ b/discord_bot/utils.py
@@ -180,7 +180,7 @@ def retry_discord_message_command(func, *args, **kwargs):
             sleep(ex.retry_after)
             raise SkipRetrySleep('Skip sleep since we slept already')
     post_exception_functions = [check_429]
-    exceptions = (HTTPException, RateLimited, DiscordServerError)
+    exceptions = (HTTPException, RateLimited, DiscordServerError, TimeoutError)
     return retry_command(func, *args, **kwargs, accepted_exceptions=exceptions, post_exception_functions=post_exception_functions)
 
 async def async_retry_discord_message_command(func, *args, **kwargs):
@@ -192,5 +192,5 @@ async def async_retry_discord_message_command(func, *args, **kwargs):
             await async_sleep(ex.retry_after)
             raise SkipRetrySleep('Skip sleep since we slept already')
     post_exception_functions = [check_429]
-    exceptions = (HTTPException, RateLimited, DiscordServerError)
+    exceptions = (HTTPException, RateLimited, DiscordServerError, TimeoutError)
     return await async_retry_command(func, *args, **kwargs, accepted_exceptions=exceptions, post_exception_functions=post_exception_functions)


### PR DESCRIPTION
Error

```
Traceback (most recent call last):
  File "/opt/discord-venv/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 1055, in start
    message, payload = await protocol.read()  # type: ignore[union-attr]
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/discord-venv/lib/python3.12/site-packages/aiohttp/streams.py", line 668, in read
    await self._waiter
asyncio.exceptions.CancelledError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/discord-venv/lib/python3.12/site-packages/discord_bot/cogs/markov.py", line 149, in main_loop
    await self.__main_loop()
  File "/opt/discord-venv/lib/python3.12/site-packages/discord_bot/cogs/markov.py", line 183, in __main_loop
    last_message = await async_retry_discord_message_command(channel.fetch_message, markov_channel.last_message_id)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/discord-venv/lib/python3.12/site-packages/discord_bot/utils.py", line 196, in async_retry_discord_message_command
    return await async_retry_command(func, *args, **kwargs, accepted_exceptions=exceptions, post_exception_functions=post_exception_functions)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/discord-venv/lib/python3.12/site-packages/discord_bot/utils.py", line 160, in async_retry_command
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/discord-venv/lib/python3.12/site-packages/discord/abc.py", line 1684, in fetch_message
    data = await self._state.http.get_message(channel.id, id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/discord-venv/lib/python3.12/site-packages/discord/http.py", line 638, in request
    async with self.__session.request(method, url, **kwargs) as response:
  File "/opt/discord-venv/lib/python3.12/site-packages/aiohttp/client.py", line 1423, in __aenter__
    self._resp: _RetType = await self._coro
                           ^^^^^^^^^^^^^^^^
  File "/opt/discord-venv/lib/python3.12/site-packages/aiohttp/client.py", line 728, in _request
    await resp.start(conn)
  File "/opt/discord-venv/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 1050, in start
    with self._timer:
  File "/opt/discord-venv/lib/python3.12/site-packages/aiohttp/helpers.py", line 671, in __exit__
    raise asyncio.TimeoutError from exc_val
TimeoutError
```