### PR TITLE
Small fixups

### DIFF
--- a/discord_bot/cogs/music.py
+++ b/discord_bot/cogs/music.py
@@ -471,11 +471,13 @@ class Music(CogHelper): #pylint:disable=too-many-public-methods
             await func()
         return
 
-    async def __ensure_video_download_result(self, source_download: SourceDownload):
+    # Take both source dict and source download
+    # Since source download might be none
+    async def __ensure_video_download_result(self, source_dict: SourceDict, source_download: SourceDownload):
         if source_download is None:
-            self.message_queue.iterate_source_lifecycle(source_download.source_dict, SourceLifecycleStage.EDIT,
-                                                        partial(source_download.source_dict.edit_message),
-                                                        f'Issue downloading video "{str(source_download.source_dict)}", skipping', delete_after=self.delete_after)
+            self.message_queue.iterate_source_lifecycle(source_dict, SourceLifecycleStage.EDIT,
+                                                        partial(source_dict.edit_message),
+                                                        f'Issue downloading video "{str(source_dict)}", skipping', delete_after=self.delete_after)
             return False
         return True
 
@@ -594,7 +596,7 @@ class Music(CogHelper): #pylint:disable=too-many-public-methods
                 self.logger.error(f'Music :: Unknown error while downloading video "{str(source_dict)}", {str(e)}')
                 source_download = None
         # Final none check in case we couldn't download video
-        if not await self.__ensure_video_download_result(source_download):
+        if not await self.__ensure_video_download_result(source_dict, source_download):
             return
 
         for func in source_dict.post_download_callback_functions:

--- a/discord_bot/cogs/music_helpers/download_client.py
+++ b/discord_bot/cogs/music_helpers/download_client.py
@@ -177,7 +177,10 @@ class DownloadClient():
 
         playlist_id : ID of youtube playlist
         '''
-        return self.youtube_client.playlist_get(playlist_id)
+        items = []
+        for item in self.youtube_client.playlist_get(playlist_id):
+            items.append(f'{YOUTUBE_VIDEO_PREFIX}{item}')
+        return items
 
     async def __check_source_types(self, search: str, loop: AbstractEventLoop, message_queue: MessageQueue, text_channel: TextChannel):
         '''

--- a/tests/cogs/music_helpers/test_download_client.py
+++ b/tests/cogs/music_helpers/test_download_client.py
@@ -53,7 +53,7 @@ class MockYoutubeClient():
 
     def playlist_get(self, _playlist_id):
         return [
-            'https://example.foo.com'
+            'aaaaaaaaaaaaaa'
         ]
 
 class MockResponse():
@@ -177,7 +177,7 @@ async def test_youtube_playlist():
     loop = asyncio.get_running_loop()
     x = DownloadClient(None, youtube_client=MockYoutubeClient())
     result = await x.check_source('https://www.youtube.com/playlist?list=11111', '1234', 'foo bar requester', '2345', loop, 5, MessageQueue(), FakeChannel())
-    assert result[0].search_string == 'https://example.foo.com'
+    assert result[0].search_string == 'https://www.youtube.com/watch?v=aaaaaaaaaaaaaa'
     assert result[0].search_type == SearchType.DIRECT
 
 @pytest.mark.asyncio(scope="session")
@@ -186,7 +186,7 @@ async def test_youtube_playlist_shuffle():
     x = DownloadClient(None, youtube_client=MockYoutubeClient())
     mq = MessageQueue()
     result = await x.check_source('https://www.youtube.com/playlist?list=11111 shuffle', '1234', 'foo bar requester', '2345', loop, 5, mq, FakeChannel())
-    assert result[0].search_string == 'https://example.foo.com'
+    assert result[0].search_string == 'https://www.youtube.com/watch?v=aaaaaaaaaaaaaa'
     assert result[0].search_type == SearchType.DIRECT
     assert mq.get_source_lifecycle() is None
 


### PR DESCRIPTION
```2025-01-07T00.52.16 - ERROR - 'NoneType' object has no attribute 'source_dict'
Traceback (most recent call last):
  File "/opt/discord-venv/lib/python3.12/site-packages/discord_bot/utils/common.py", line 233, in loop_runner
    await function()
  File "/opt/discord-venv/lib/python3.12/site-packages/discord_bot/cogs/music.py", line 597, in download_files
    if not await self.__ensure_video_download_result(source_download):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/discord-venv/lib/python3.12/site-packages/discord_bot/cogs/music.py", line 476, in __ensure_video_download_result
    self.message_queue.iterate_source_lifecycle(source_download.source_dict, SourceLifecycleStage.EDIT,
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'source_dict'
2025-01-07T00.52.16 - ERROR - Traceback (most recent call last):
  File "/opt/discord-venv/lib/python3.12/site-packages/discord_bot/utils/common.py", line 233, in loop_runner
    await function()
  File "/opt/discord-venv/lib/python3.12/site-packages/discord_bot/cogs/music.py", line 597, in download_files
    if not await self.__ensure_video_download_result(source_download):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/discord-venv/lib/python3.12/site-packages/discord_bot/cogs/music.py", line 476, in __ensure_video_download_result
    self.message_queue.iterate_source_lifecycle(source_download.source_dict, SourceLifecycleStage.EDIT,
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'source_dict'

2025-01-07T00.52.16 - ERROR - 'NoneType' object has no attribute 'source_dict'```