### PR TITLE
chore: change player to use copied files

### DIFF
--- a/discord_bot/cogs/music_helpers/download_client.py
+++ b/discord_bot/cogs/music_helpers/download_client.py
@@ -101,7 +101,7 @@ class DownloadClient():
     '''
     Download Client using yt-dlp
     '''
-    def __init__(self, ytdl: YoutubeDL, message_queue: MessageQueue,
+    def __init__(self, ytdl: YoutubeDL, download_dir: Path, message_queue: MessageQueue,
                  spotify_client: SpotifyClient = None, youtube_client: YoutubeClient = None, youtube_music_client: YoutubeMusicClient = None,
                  search_cache_client: SearchCacheClient = None,
                  number_shuffles: int = 5):
@@ -109,6 +109,7 @@ class DownloadClient():
         Init download client
 
         ytdl : YoutubeDL Client
+        download_dir : Directory to place after tempfile download
         message_queue : The bots message queue
         spotify_client : Spotify Client
         youtube_client : Youtube Client
@@ -117,6 +118,7 @@ class DownloadClient():
         number_shuffles : Number of shuffles post api calls
         '''
         self.ytdl = ytdl
+        self.download_dir = download_dir
         self.message_queue = message_queue
         self.spotify_client = spotify_client
         self.youtube_client = youtube_client
@@ -168,6 +170,10 @@ class DownloadClient():
                         file_path = None
                 except (KeyError, IndexError):
                     file_path = None
+                # Move file to download dir after finished
+                new_path = self.download_dir / file_path.name
+                file_path.rename(new_path)
+                file_path = new_path
             span.set_status(StatusCode.OK)
             return SourceDownload(file_path, data, source_dict)
 

--- a/discord_bot/cogs/music_helpers/source_download.py
+++ b/discord_bot/cogs/music_helpers/source_download.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from shutil import copyfile
 
 from discord_bot.cogs.music_helpers.common import YT_DLP_KEYS
 from discord_bot.cogs.music_helpers.source_dict import SourceDict
@@ -27,7 +28,7 @@ class SourceDownload():
         self.file_path = file_path
         self.base_path = file_path
 
-    def ready_file(self, file_dir: Path = None, move_file: bool = False):
+    def ready_file(self, file_dir: Path = None):
         '''
         Ready file for server
 
@@ -38,7 +39,7 @@ class SourceDownload():
         '''
         guild_path = file_dir or self.file_path.parent / f'{self.source_dict.guild_id}'
         guild_path.mkdir(exist_ok=True)
-        if self.file_path:
+        if self.base_path:
             # The modified time of download videos can be the time when it was actually uploaded to youtube
             # Touch here to update the modified time, so that the cleanup check works as intendend
             # Rename file to a random uuid name, that way we can have diff videos with same/similar names
@@ -48,13 +49,8 @@ class SourceDownload():
             if not self.base_path.exists():
                 # Usually happened if you stopped bot while downloading
                 raise FileNotFoundError('Unable to locate base path')
-            if move_file:
-                self.base_path.rename(uuid_path)
-                self.file_path = uuid_path
-                self.base_path = uuid_path
-            else:
-                uuid_path.symlink_to(self.base_path)
-                self.file_path = uuid_path
+            copyfile(str(self.base_path), str(uuid_path))
+            self.file_path = uuid_path
 
     def delete(self):
         '''

--- a/tests/cogs/music_helpers/test_download_client.py
+++ b/tests/cogs/music_helpers/test_download_client.py
@@ -1,6 +1,7 @@
 import asyncio
 from functools import partial
-from tempfile import NamedTemporaryFile
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from googleapiclient.errors import HttpError
 import pytest
@@ -81,8 +82,8 @@ class MockYoutubeRaise():
         raise HttpError(MockResponse(), 'foo'.encode('utf-8'))
 
 class MockYTDLP():
-    def __init__(self):
-        pass
+    def __init__(self, fake_file_path : Path = 'foo-bar.mp3'):
+        self.fake_file_path = fake_file_path
 
     def extract_info(self, _search_string, download=True):
         data = {
@@ -99,7 +100,7 @@ class MockYTDLP():
         if download:
             data['entries'][0]['requested_downloads'] = [
                 {
-                    'filepath': 'foo-bar.mp3',
+                    'filepath': self.fake_file_path,
                     'original_path': 'foo-bar-original.mp3',
                 },
             ]
@@ -123,7 +124,7 @@ class MockYoutubeMusic():
 
 @pytest.mark.asyncio
 async def test_spotify_message_check():
-    x = DownloadClient(None, MessageQueue())
+    x = DownloadClient(None, None, MessageQueue())
     with pytest.raises(InvalidSearchURL) as exc:
         await x.check_source('https://open.spotify.com/playlist/1111', '1234', 'foo bar requester', '2345', None, 5, FakeChannel())
     assert str(exc.value) == 'Missing spotify creds'
@@ -133,7 +134,7 @@ async def test_spotify_message_check():
 async def test_spotify_throw_exception():
     loop = asyncio.get_running_loop()
     mq = MessageQueue()
-    x = DownloadClient(None, mq, spotify_client=MockSpotifyRaise())
+    x = DownloadClient(None, None, mq, spotify_client=MockSpotifyRaise())
     with pytest.raises(ThirdPartyException) as exc:
         await x.check_source('https://open.spotify.com/album/1111', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert 'Issue fetching spotify info' in str(exc.value)
@@ -146,7 +147,7 @@ async def test_spotify_throw_exception():
 async def test_spotify_throw_exception_403():
     loop = asyncio.get_running_loop()
     mq = MessageQueue()
-    x = DownloadClient(None, mq, spotify_client=MockSpotifyRaiseUnauth())
+    x = DownloadClient(None, None, mq, spotify_client=MockSpotifyRaiseUnauth())
     with pytest.raises(ThirdPartyException) as exc:
         await x.check_source('https://open.spotify.com/album/1111', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert 'Issue fetching spotify info' in str(exc.value)
@@ -158,7 +159,7 @@ async def test_spotify_throw_exception_403():
 @pytest.mark.asyncio(scope="session")
 async def test_spotify_album_get():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(None, MessageQueue(), spotify_client=MockSpotifyClient())
+    x = DownloadClient(None, None, MessageQueue(), spotify_client=MockSpotifyClient())
     result = await x.check_source('https://open.spotify.com/album/1111', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert result[0].requester_id == '2345'
     assert result[0].search_string == 'foo track foo artists'
@@ -178,7 +179,7 @@ async def test_spotify_album_with_cache():
         },
         source_dict)
         search_client.iterate(download)
-        x = DownloadClient(None, MessageQueue(), spotify_client=MockSpotifyClient(), search_cache_client=search_client)
+        x = DownloadClient(None, None, MessageQueue(), spotify_client=MockSpotifyClient(), search_cache_client=search_client)
         result = await x.check_source('https://open.spotify.com/album/1111', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
         assert result[0].requester_id == '2345'
         assert result[0].search_string == 'https://youtube.com/watch=v?adafaonoasnfo'
@@ -193,7 +194,7 @@ async def test_spotify_album_with_cache_miss_and_youtube_fallback():
         BASE.metadata.bind = engine
         loop = asyncio.get_running_loop()
         search_client = SearchCacheClient(partial(mock_session, engine), 10)
-        x = DownloadClient(None, MessageQueue(), spotify_client=MockSpotifyClient(), youtube_music_client=MockYoutubeMusic(), search_cache_client=search_client)
+        x = DownloadClient(None, None, MessageQueue(), spotify_client=MockSpotifyClient(), youtube_music_client=MockYoutubeMusic(), search_cache_client=search_client)
         result = await x.check_source('https://open.spotify.com/album/1111', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
         assert result[0].requester_id == '2345'
         assert result[0].search_string == 'https://www.youtube.com/watch?v=vid-1234'
@@ -204,7 +205,7 @@ async def test_spotify_album_with_cache_miss_and_youtube_fallback():
 async def test_spotify_album_get_shuffle():
     loop = asyncio.get_running_loop()
     mq = MessageQueue()
-    x = DownloadClient(None, mq, spotify_client=MockSpotifyClient())
+    x = DownloadClient(None, None, mq, spotify_client=MockSpotifyClient())
     result = await x.check_source('https://open.spotify.com/album/1111 shuffle', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert result[0].requester_id == '2345'
     assert result[0].search_string == 'foo track foo artists'
@@ -216,28 +217,28 @@ async def test_spotify_album_get_shuffle():
 @pytest.mark.asyncio(scope="session")
 async def test_spotify_playlist_get():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(None, MessageQueue(), spotify_client=MockSpotifyClient())
+    x = DownloadClient(None, None, MessageQueue(), spotify_client=MockSpotifyClient())
     result = await x.check_source('https://open.spotify.com/playlist/1111', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert result[0].search_string == 'foo track foo artists'
 
 @pytest.mark.asyncio(scope="session")
 async def test_spotify_playlist_get_shuffle():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(None, MessageQueue(), spotify_client=MockSpotifyClient())
+    x = DownloadClient(None, None, MessageQueue(), spotify_client=MockSpotifyClient())
     result = await x.check_source('https://open.spotify.com/playlist/1111 shuffle', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert result[0].search_string == 'foo track foo artists'
 
 @pytest.mark.asyncio(scope="session")
 async def test_spotify_track_get():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(None, MessageQueue(), spotify_client=MockSpotifyClient())
+    x = DownloadClient(None, None, MessageQueue(), spotify_client=MockSpotifyClient())
     result = await x.check_source('https://open.spotify.com/track/1111', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert result[0].search_string == 'foo track foo artists'
 
 @pytest.mark.asyncio(scope="session")
 async def test_youtube_no_creds():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(None, MessageQueue())
+    x = DownloadClient(None, None, MessageQueue())
     with pytest.raises(InvalidSearchURL) as exc:
         await x.check_source('https://www.youtube.com/playlist?list=11111', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert 'Missing youtube creds' in str(exc.value)
@@ -245,7 +246,7 @@ async def test_youtube_no_creds():
 @pytest.mark.asyncio(scope="session")
 async def test_youtube_playlist():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(None, MessageQueue(), youtube_client=MockYoutubeClient())
+    x = DownloadClient(None, None, MessageQueue(), youtube_client=MockYoutubeClient())
     result = await x.check_source('https://www.youtube.com/playlist?list=11111', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert result[0].search_string == 'https://www.youtube.com/watch?v=aaaaaaaaaaaaaa'
     assert result[0].search_type == SearchType.DIRECT
@@ -254,7 +255,7 @@ async def test_youtube_playlist():
 async def test_youtube_playlist_shuffle():
     loop = asyncio.get_running_loop()
     mq = MessageQueue()
-    x = DownloadClient(None, mq, youtube_client=MockYoutubeClient())
+    x = DownloadClient(None, None, mq, youtube_client=MockYoutubeClient())
     result = await x.check_source('https://www.youtube.com/playlist?list=11111 shuffle', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert result[0].search_string == 'https://www.youtube.com/watch?v=aaaaaaaaaaaaaa'
     assert result[0].search_type == SearchType.DIRECT
@@ -263,7 +264,7 @@ async def test_youtube_playlist_shuffle():
 @pytest.mark.asyncio(scope="session")
 async def test_youtube_error():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(None, MessageQueue(), youtube_client=MockYoutubeRaise())
+    x = DownloadClient(None, None, MessageQueue(), youtube_client=MockYoutubeRaise())
     with pytest.raises(ThirdPartyException) as exc:
         await x.check_source('https://www.youtube.com/playlist?list=11111', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert 'Issue fetching youtube info' in str(exc.value)
@@ -271,7 +272,7 @@ async def test_youtube_error():
 @pytest.mark.asyncio(scope="session")
 async def test_youtube_short():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(None, MessageQueue())
+    x = DownloadClient(None, None, MessageQueue())
     result = await x.check_source('https://www.youtube.com/shorts/aaaaaaaaaaa?extra=foo', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert result[0].search_string == 'https://www.youtube.com/shorts/aaaaaaaaaaa'
     assert result[0].search_type == SearchType.DIRECT
@@ -279,7 +280,7 @@ async def test_youtube_short():
 @pytest.mark.asyncio(scope="session")
 async def test_youtube_video():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(None, MessageQueue())
+    x = DownloadClient(None, None, MessageQueue())
     result = await x.check_source('https://www.youtube.com/watch?v=aaaaaaaaaaa?extra=foo', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert result[0].search_string == 'https://www.youtube.com/watch?v=aaaaaaaaaaa'
     assert result[0].search_type == SearchType.DIRECT
@@ -287,7 +288,7 @@ async def test_youtube_video():
 @pytest.mark.asyncio(scope="session")
 async def test_fxtwitter():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(None, MessageQueue())
+    x = DownloadClient(None, None, MessageQueue())
     result = await x.check_source('https://fxtwitter.com/NicoleCahill_/status/1842208144073576615', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert result[0].search_string == 'https://x.com/NicoleCahill_/status/1842208144073576615'
     assert result[0].search_type == SearchType.DIRECT
@@ -295,7 +296,7 @@ async def test_fxtwitter():
 @pytest.mark.asyncio(scope="session")
 async def test_basic_search():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(None, MessageQueue())
+    x = DownloadClient(None, None, MessageQueue())
     result = await x.check_source('foo bar', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert result[0].search_string == 'foo bar'
     assert result[0].search_type == SearchType.SEARCH
@@ -303,15 +304,17 @@ async def test_basic_search():
 @pytest.mark.asyncio(scope="session")
 async def test_prepare_source():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(MockYTDLP(), MessageQueue())
-    y = SourceDict('1234', 'requester name', 'requester-id', 'foo bar', SearchType.SEARCH)
-    result = await x.create_source(y, loop)
-    assert result.webpage_url == 'https://example.foo.com'
+    with TemporaryDirectory() as tmp_dir:
+        with NamedTemporaryFile(delete=False) as tmp_file:
+            x = DownloadClient(MockYTDLP(fake_file_path=Path(tmp_file.name)), Path(tmp_dir), MessageQueue())
+            y = SourceDict('1234', 'requester name', 'requester-id', 'foo bar', SearchType.SEARCH)
+            result = await x.create_source(y, loop)
+            assert result.webpage_url == 'https://example.foo.com'
 
 @pytest.mark.asyncio(scope="session")
 async def test_prepare_source_no_download():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(MockYTDLP(), MessageQueue())
+    x = DownloadClient(MockYTDLP(), None, MessageQueue())
     y = SourceDict('1234', 'requester name', 'requester-id', 'foo bar', SearchType.SEARCH, download_file=False)
     result = await x.create_source(y, loop)
     assert result.webpage_url == 'https://example.foo.com'
@@ -319,25 +322,25 @@ async def test_prepare_source_no_download():
 @pytest.mark.asyncio(scope="session")
 async def test_prepare_source_errors():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(yield_dlp_error('Sign in to confirm your age. This video may be inappropriate for some users'), MessageQueue())
+    x = DownloadClient(yield_dlp_error('Sign in to confirm your age. This video may be inappropriate for some users'), None, MessageQueue())
     y = SourceDict('1234', 'requester name', 'requester-id', 'foo bar', SearchType.SEARCH, download_file=False)
     with pytest.raises(DownloadClientException) as exc:
         await x.create_source(y, loop)
     assert 'Video Aged restricted' in str(exc.value)
 
-    x = DownloadClient(yield_dlp_error('Video unavailable'), MessageQueue())
+    x = DownloadClient(yield_dlp_error('Video unavailable'), None, MessageQueue())
     y = SourceDict('1234', 'requester name', 'requester-id', 'foo bar', SearchType.SEARCH, download_file=False)
     with pytest.raises(DownloadClientException) as exc:
         await x.create_source(y, loop)
     assert 'Video is unavailable' in str(exc.value)
 
-    x = DownloadClient(yield_dlp_error('Private video'), MessageQueue())
+    x = DownloadClient(yield_dlp_error('Private video'), None, MessageQueue())
     y = SourceDict('1234', 'requester name', 'requester-id', 'foo bar', SearchType.SEARCH, download_file=False)
     with pytest.raises(DownloadClientException) as exc:
         await x.create_source(y, loop)
     assert 'Video is private' in str(exc.value)
 
-    x = DownloadClient(yield_dlp_error("Sign in to confirm you're not a bot"), MessageQueue())
+    x = DownloadClient(yield_dlp_error("Sign in to confirm you're not a bot"), None, MessageQueue())
     y = SourceDict('1234', 'requester name', 'requester-id', 'foo bar', SearchType.SEARCH, download_file=False)
     with pytest.raises(DownloadClientException) as exc:
         await x.create_source(y, loop)
@@ -346,7 +349,7 @@ async def test_prepare_source_errors():
 @pytest.mark.asyncio(scope="session")
 async def test_basic_search_with_youtube_music():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(None, MessageQueue(), youtube_music_client=MockYoutubeMusic)
+    x = DownloadClient(None, None, MessageQueue(), youtube_music_client=MockYoutubeMusic)
     result = await x.check_source('foo bar', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert result[0].search_string == 'https://www.youtube.com/watch?v=vid-1234'
     assert result[0].search_type == SearchType.SEARCH
@@ -355,7 +358,7 @@ async def test_basic_search_with_youtube_music():
 @pytest.mark.asyncio(scope="session")
 async def test_basic_search_with_youtube_music_skips_direct():
     loop = asyncio.get_running_loop()
-    x = DownloadClient(None, MessageQueue(), youtube_music_client=MockYoutubeMusic)
+    x = DownloadClient(None, None, MessageQueue(), youtube_music_client=MockYoutubeMusic)
     result = await x.check_source('https://www.youtube.com/watch?v=aaaaaaaaaaa', '1234', 'foo bar requester', '2345', loop, 5, FakeChannel())
     assert result[0].search_string == 'https://www.youtube.com/watch?v=aaaaaaaaaaa'
     assert result[0].search_type == SearchType.DIRECT

--- a/tests/cogs/music_helpers/test_source_download.py
+++ b/tests/cogs/music_helpers/test_source_download.py
@@ -19,18 +19,3 @@ def test_source_download_with_cache():
             x.delete()
             assert not x.file_path.exists()
             assert file_path.exists()
-
-def test_source_download_without_cache():
-    with TemporaryDirectory() as tmp_dir:
-        with NamedTemporaryFile(dir=tmp_dir, suffix='.mp3', delete=False) as tmp_file:
-            file_path = Path(tmp_file.name)
-            file_path.write_text('testing', encoding='utf-8')
-            y = SourceDict('123', 'foo bar authr', '234', 'foo bar video', SearchType.SEARCH)
-            x = SourceDownload(file_path, {'webpage_url': 'https://foo.example'}, y)
-            x.ready_file(move_file=True)
-            assert str(x) == 'https://foo.example'
-            assert str(x.file_path) != str(file_path)
-            assert '/123/' in str(x.file_path)
-            x.delete()
-            assert not x.file_path.exists()
-            assert not file_path.exists()

--- a/tests/cogs/test_music.py
+++ b/tests/cogs/test_music.py
@@ -1114,6 +1114,57 @@ async def test_cache_cleanup_removes(mocker, freezer):
                     await cog.cache_cleanup()
                     assert not cog.video_cache.get_webpage_url_item(s)
 
+@pytest.mark.asyncio
+async def test_cache_cleanup_skips_source_in_transit(mocker, freezer):
+    with NamedTemporaryFile(suffix='.sql') as temp_db:
+        engine = create_engine(f'sqlite:///{temp_db.name}')
+        BASE.metadata.create_all(engine)
+        BASE.metadata.bind = engine
+
+        config = {
+            'general': {
+                'include': {
+                    'music': True
+                },
+            },
+            'music': {
+                'download': {
+                    'cache': {
+                        'enable_cache_files': True,
+                        'max_cache_files': 1,
+                    }
+                }
+            }
+        }
+        fake_bot = fake_bot_yielder()()
+        cog = Music(fake_bot, config, engine)
+        mocker.patch('discord_bot.cogs.music.sleep', return_value=True)
+        mocker.patch.object(MusicPlayer, 'start_tasks')
+        fake_channel = FakeChannel(members=[fake_bot.user])
+        fake_voice = FakeVoiceClient(channel=fake_channel)
+        fake_guild = FakeGuild(voice=fake_voice)
+        await cog.get_player(fake_guild.id, ctx=FakeContext(fake_guild=fake_guild, fake_bot=fake_bot))
+        with TemporaryDirectory() as tmp_dir:
+            with NamedTemporaryFile(dir=tmp_dir, suffix='.mp3', delete=False) as tmp_file:
+                file_path = Path(tmp_file.name)
+                file_path.write_text('testing', encoding='utf-8')
+                with NamedTemporaryFile(dir=tmp_dir, suffix='.mp3', delete=False) as tmp_file2:
+                    file_path2 = Path(tmp_file2.name)
+                    file_path2.write_text('testing', encoding='utf-8')
+                    s = SourceDict('123', 'foo bar authr', '234', 'https://foo.example', SearchType.DIRECT)
+                    sd = SourceDownload(file_path, {'webpage_url': 'https://foo.example'}, s)
+                    s2 = SourceDict('123', 'foo bar authr', '234', 'https://foo.example/bar', SearchType.DIRECT)
+                    sd2 = SourceDownload(file_path2, {'webpage_url': 'https://foo.example/bar'}, s2)
+                    cog.video_cache.iterate_file(sd)
+                    cog.video_cache.iterate_file(sd2)
+                    cog.video_cache.ready_remove()
+                    # Run twice so heartbeat passses
+                    freezer.move_to('2024-12-01 12:00:00')
+                    await cog.cache_cleanup()
+                    freezer.move_to('2024-12-02 12:00:00')
+                    cog.sources_in_transit[sd.source_dict.uuid] = str(sd.base_path)
+                    await cog.cache_cleanup()
+                    assert cog.video_cache.get_webpage_url_item(s)
 
 @pytest.mark.asyncio
 async def test_add_source_to_player_caches_video(mocker):


### PR DESCRIPTION
Changeup how players use a copied files instead of a symlink. This is done for a couple of reasons:
- Players don't attempt to read from the same file and clog resources
- We know the files in the download dir are free to use