### PR TITLE
feat: expose history in playlist commands

### DIFF
--- a/docs/music.md
+++ b/docs/music.md
@@ -1,13 +1,13 @@
 # Music Cog
 
-Play audio from Youtube videos in voice chat. The bot can be called to join voice chat, and Youtube videos can be requested to be downloaded, processed, and played in the voice chat. Video audio will play one at a time and can be added to a queue to be played after the current video audio is played or skipped.
+Play audio from internet videos in voice chat. The bot can be called to join voice chat, and videos can be requested to be downloaded, processed, and played in the voice chat. Video audio will play one at a time and can be added to a queue to be played after the current video audio is played or skipped.
 
 The bot is designed to be able to run on multiple servers at the same time.
 
 ## Inputs
 
 Potential input includes
-- A string that will be searched in Youtube and download the first result
+- A string that will be searched in Youtube Music and download the first result
 - A direct Youtube link that will be downloaded
 - A Spotify playlist or album (if Spotify credentials are given in the config)
 - A Youtube playlist (if Youtube credentials are given in the config)
@@ -62,10 +62,10 @@ If you would like to move the queue messages to a different channel, call `!move
 
 ## Playlist Functions
 
-If database creds are given to the bot, playlists can be created and updated to the server. This will allow you to save lists of Youtube videos to be played within the server. By default, a "history" playlist is created which adds previously played videos from the server. Anyone can queue these videos up in the server using:
+If database creds are given to the bot, playlists can be created and updated to the server. This will allow you to save lists of videos to be played within the server. By default, a "history" playlist is created which adds previously played videos from the server. Anyone can queue these videos up in the server using:
 
 ```
-!random-play
+!playlist queue 0
 ```
 
 To list the current playlists
@@ -134,7 +134,7 @@ Remove an item from a playlist
 
 ## Spotify Enablement
 
-You can pass [Spotify API](https://developer.spotify.com/) credentials to the config to allow for Spotify playlists and albums to be given as input. This will request the track information from Spotify, then the bot will run a Youtube search for "`<artist name>` `<song name>`" in Youtube, and download the first result.
+You can pass [Spotify API](https://developer.spotify.com/) credentials to the config to allow for Spotify playlists and albums to be given as input. This will request the track information from Spotify, then the bot will run a search for "`<artist name>` `<song name>`", and download the first result.
 
 You can pass the Spotify credentials into the config:
 
@@ -155,7 +155,7 @@ You can pass Youtube API credentials into the config:
 ```
 music:
   download:
-    youtube_api_key: secret-Youtube-api-key
+    youtube_api_key: secret-youtube-api-key
 ```
 
 ## Multi Video Input Shuffles
@@ -163,12 +163,12 @@ music:
 Note that with either Spotify playlists/albums or Youtube playlist input, you can pass `shuffle` to the play input to have the videos shuffled.
 
 ```
-!play <spotify-playlist-link> shuffle
+!play <spotify-playlist-link/youtube-playlist-link> shuffle
 ```
 
 ## Under the Hood
 
-All Youtube videos are downloaded by the bot via [yt-dlp](https://github.com/yt-dlp/yt-dlp). The video audio is then left on disk and deleted after the video is played. You can specify what directory the videos are downloaded to in the config:
+All videos are downloaded by the bot via [yt-dlp](https://github.com/yt-dlp/yt-dlp). The video audio is then left on disk and deleted after the video is played. You can specify what directory the videos are downloaded to in the config:
 
 ```
 music:
@@ -238,7 +238,7 @@ Here is a diagram of how the layers of caching interact with each other:
 
 ### Audio Processing
 
-You can also choose to enable audio processing, which will use FFMPEG to normalize the audio of all videos downloaded, since some Youtube videos have different volumes to them. This will also remove "dead air" from the start and end of videos after they are downloaded.
+You can also choose to enable audio processing, which will use FFMPEG to normalize the audio of all videos downloaded, since some videos have different volumes to them. This will also remove "dead air" from the start and end of videos after they are downloaded.
 
 
 `ffmpeg` must be installed on the machine is using to be able to use this feature.


### PR DESCRIPTION
Expose the history playlist in the normal !playlist functions, this is for a few reasons:
- add ability to remove songs
- more closely align history playlist with regular functions
- encourage folks to use !playlist more generally