### PR TITLE
fix: dont check if voice client active on stop

### DIFF
--- a/discord_bot/cogs/music.py
+++ b/discord_bot/cogs/music.py
@@ -1405,7 +1405,7 @@ class Music(CogHelper): #pylint:disable=too-many-public-methods
         '''
         if not await self.__check_author_voice_chat(ctx):
             return
-        player = await self.get_player(ctx.guild.id, ctx=ctx, check_voice_client_active=True)
+        player = await self.get_player(ctx.guild.id, ctx=ctx)
         if not player:
             return
         self.logger.info(f'Calling stop for guild {ctx.guild.id}')


### PR DESCRIPTION
Client might not be active or playing anything at the moment, thats fine We just need to check if any player exists and then exit