### PR TITLE
fix(dispatch): stop lock-retry from clobbering newer bundle payloads

### DIFF
--- a/discord_bot/interfaces/dispatch_protocols.py
+++ b/discord_bot/interfaces/dispatch_protocols.py
@@ -35,8 +35,15 @@ class WorkQueue(ABC):
         '''Add a new entry to the queue.'''
 
     @abstractmethod
-    async def enqueue_unique(self, member: str, payload: dict, priority: int) -> None:
-        '''Add an entry only if *member* is not already queued; always update payload.'''
+    async def enqueue_unique(self, member: str, payload: dict, priority: int,
+                             overwrite: bool = True) -> None:
+        '''Add an entry only if *member* is not already queued.
+
+        When *overwrite* is True (the default, used for fresh updates) the stored
+        payload is replaced so the newest content wins. When False (used by the
+        lock-retry re-enqueue path, which may be carrying an already-stale payload)
+        the payload is only written if none is currently stored — so a newer update
+        that arrived between dequeue and re-enqueue is never clobbered.'''
 
     @abstractmethod
     async def dequeue(self, timeout: float = 1.0) -> tuple[str, dict] | None:

--- a/discord_bot/utils/dispatch_queue.py
+++ b/discord_bot/utils/dispatch_queue.py
@@ -69,16 +69,25 @@ class RedisDispatchQueue:
     # Enqueueing
     # ------------------------------------------------------------------
 
-    async def enqueue_unique(self, member: str, payload: dict, priority: int) -> None:
+    async def enqueue_unique(self, member: str, payload: dict, priority: int,
+                             overwrite: bool = True) -> None:
         '''
-        Store payload and ZADD NX — payload always overwritten, queue entry
-        only added if the member is not already present.
+        Store payload and ZADD NX — queue entry only added if the member is not
+        already present.
 
         Used for mutable bundle updates: rapid-fire calls collapse to one entry
         (same semantics as the in-memory sentinel dedup).
+
+        ``overwrite`` controls the payload write so the newest content always wins:
+
+        - True (default) — fresh updates ``SET`` the payload unconditionally.
+        - False — the lock-retry re-enqueue path may be carrying a payload that is
+          already stale (a newer update can land between ``dequeue`` deleting the
+          payload and this re-enqueue). ``SET NX`` only restores the payload when
+          none is stored, so a newer update is never clobbered.
         '''
         pipe = self._redis.pipeline()
-        pipe.set(self.payload_key(member), json.dumps(payload), ex=_PAYLOAD_TTL)
+        pipe.set(self.payload_key(member), json.dumps(payload), ex=_PAYLOAD_TTL, nx=not overwrite)
         pipe.zadd(self._queue_key, {member: self._score(priority)}, nx=True)
         await pipe.execute()
 

--- a/discord_bot/workers/asyncio_queues.py
+++ b/discord_bot/workers/asyncio_queues.py
@@ -47,14 +47,26 @@ class AsyncioWorkQueue(WorkQueue):
         self._queue: asyncio.PriorityQueue = asyncio.PriorityQueue()
         self._seq = itertools.count()
         self._dedup: set[str] = set()
+        # Latest payload per unique member, mirroring the Redis payload key so the
+        # newest content wins on coalesced updates. Non-unique enqueue() items carry
+        # their payload inline in the queue tuple and never appear here.
+        self._payloads: dict[str, dict] = {}
         self._results: dict[str, dict] = {}
 
     async def enqueue(self, member: str, payload: dict, priority: int) -> None:
         await self._queue.put((priority, next(self._seq), member, payload))
 
-    async def enqueue_unique(self, member: str, payload: dict, priority: int) -> None:
+    async def enqueue_unique(self, member: str, payload: dict, priority: int,
+                             overwrite: bool = True) -> None:
+        # Keep the newest payload (overwrite) unless this is a lock-retry re-enqueue
+        # carrying a possibly-stale payload (overwrite=False), which must not clobber
+        # a newer update that arrived after the original dequeue.
+        if overwrite or member not in self._payloads:
+            self._payloads[member] = payload
         if member not in self._dedup:
             self._dedup.add(member)
+            # Payload is also stored inline as a fallback; _payloads holds the
+            # authoritative latest value resolved at dequeue time.
             await self._queue.put((priority, next(self._seq), member, payload))
 
     async def dequeue(self, timeout: float = 1.0) -> tuple[str, dict] | None:
@@ -63,6 +75,9 @@ class AsyncioWorkQueue(WorkQueue):
                 self._queue.get(), timeout=timeout
             )
             self._dedup.discard(member)
+            # Unique members store the live payload separately so coalesced updates
+            # resolve to the latest content; fall back to the inline tuple payload.
+            payload = self._payloads.pop(member, payload)
             return member, payload
         except asyncio.TimeoutError:
             return None

--- a/discord_bot/workers/message_dispatcher.py
+++ b/discord_bot/workers/message_dispatcher.py
@@ -465,7 +465,11 @@ class MessageDispatcher(DispatchClientBase):
         '''Load bundle from store, acquire lock, execute mutable update, save.'''
         acquired = await self._work_queue.acquire_lock(key)
         if not acquired:
-            await self._work_queue.enqueue_unique(f'{_MEMBER_MUTABLE}{key}', payload, DispatchPriority.HIGH)
+            # overwrite=False: this payload may be stale by now (a newer update can
+            # land while the lock is held). Re-queue the member without clobbering a
+            # fresher payload, so the newest bundle render still wins.
+            await self._work_queue.enqueue_unique(f'{_MEMBER_MUTABLE}{key}', payload,
+                                                  DispatchPriority.HIGH, overwrite=False)
             return
         try:
             async with async_otel_span_wrapper('message_dispatcher.process_mutable',
@@ -545,7 +549,10 @@ class MessageDispatcher(DispatchClientBase):
         '''
         acquired = await self._work_queue.acquire_lock(key)
         if not acquired:
-            await self._work_queue.enqueue_unique(f'{_MEMBER_REMOVE}{key}', {'key': key}, DispatchPriority.HIGH)
+            # overwrite=False for parity with the mutable retry path; the remove
+            # payload is constant so this only avoids a redundant payload write.
+            await self._work_queue.enqueue_unique(f'{_MEMBER_REMOVE}{key}', {'key': key},
+                                                  DispatchPriority.HIGH, overwrite=False)
             return
         try:
             async with async_otel_span_wrapper('message_dispatcher.remove_mutable', attributes={'key': key}):

--- a/discord_bot/workers/redis_queues.py
+++ b/discord_bot/workers/redis_queues.py
@@ -82,8 +82,9 @@ class RedisWorkQueue(WorkQueue):
     async def enqueue(self, member: str, payload: dict, priority: int) -> None:
         await self._get_queue().enqueue(member, payload, priority)
 
-    async def enqueue_unique(self, member: str, payload: dict, priority: int) -> None:
-        await self._get_queue().enqueue_unique(member, payload, priority)
+    async def enqueue_unique(self, member: str, payload: dict, priority: int,
+                             overwrite: bool = True) -> None:
+        await self._get_queue().enqueue_unique(member, payload, priority, overwrite=overwrite)
 
     async def dequeue(self, timeout: float = 1.0) -> tuple[str, dict] | None:
         return await self._get_queue().dequeue(timeout)

--- a/tests/cogs/test_message_dispatcher.py
+++ b/tests/cogs/test_message_dispatcher.py
@@ -798,6 +798,26 @@ async def test_process_mutable_lock_not_acquired_reenqueues(mocker):
 
 
 @pytest.mark.asyncio
+async def test_process_mutable_lock_retry_reenqueues_without_overwrite(mocker):
+    '''Lock-retry must re-enqueue with overwrite=False.
+
+    Regression for the frozen-bundle bug: the dequeued payload may be stale by the
+    time the lock is contended, so re-enqueuing it must not clobber a newer render
+    that arrived meanwhile (which would freeze the status message and skip its delete).
+    '''
+    dispatcher = make_dispatcher()
+    mocker.patch.object(dispatcher._work_queue, 'acquire_lock', return_value=False)  # pylint: disable=protected-access
+    spy = mocker.spy(dispatcher._work_queue, 'enqueue_unique')  # pylint: disable=protected-access
+
+    await dispatcher._process_mutable('mykey', {  # pylint: disable=protected-access
+        'key': 'mykey', 'guild_id': 1, 'content': ['stale'], 'channel_id': 100,
+    })
+
+    assert spy.call_count == 1
+    assert spy.call_args.kwargs.get('overwrite') is False
+
+
+@pytest.mark.asyncio
 async def test_process_mutable_no_channel_id_no_bundle_returns_early():
     '''_process_mutable returns early when no bundle exists and channel_id absent.'''
     dispatcher = make_dispatcher()

--- a/tests/utils/test_dispatch_queue.py
+++ b/tests/utils/test_dispatch_queue.py
@@ -75,6 +75,37 @@ async def test_enqueue_unique_nx_preserves_existing_position(dispatch_queue, red
     assert score1 == score2
 
 
+@pytest.mark.asyncio
+async def test_enqueue_unique_overwrites_payload_by_default(dispatch_queue, redis_client):
+    '''By default enqueue_unique overwrites the payload so the newest content wins.'''
+    await dispatch_queue.enqueue_unique('mutable:k', {'v': 1}, priority=0)
+    await dispatch_queue.enqueue_unique('mutable:k', {'v': 2}, priority=1)
+    raw = await redis_client.get(RedisDispatchQueue.payload_key('mutable:k'))
+    assert json.loads(raw) == {'v': 2}
+
+
+@pytest.mark.asyncio
+async def test_enqueue_unique_no_overwrite_preserves_newer_payload(dispatch_queue, redis_client):
+    '''overwrite=False (lock-retry) must not clobber a newer payload.
+
+    Regression for the frozen-bundle bug: a stale in-progress payload re-set by the
+    lock-retry path overwrote the newer "completed" render, freezing the status
+    message and skipping the delete_after that would have removed it.
+    '''
+    await dispatch_queue.enqueue_unique('mutable:k', {'v': 'new'}, priority=0)
+    await dispatch_queue.enqueue_unique('mutable:k', {'v': 'stale'}, priority=0, overwrite=False)
+    raw = await redis_client.get(RedisDispatchQueue.payload_key('mutable:k'))
+    assert json.loads(raw) == {'v': 'new'}
+
+
+@pytest.mark.asyncio
+async def test_enqueue_unique_no_overwrite_restores_absent_payload(dispatch_queue, redis_client):
+    '''overwrite=False restores the payload when none is stored (e.g. deleted on dequeue).'''
+    await dispatch_queue.enqueue_unique('mutable:k', {'v': 'retried'}, priority=0, overwrite=False)
+    raw = await redis_client.get(RedisDispatchQueue.payload_key('mutable:k'))
+    assert json.loads(raw) == {'v': 'retried'}
+
+
 # ---------------------------------------------------------------------------
 # enqueue (lines 90-93)
 # ---------------------------------------------------------------------------

--- a/tests/workers/test_asyncio_queues.py
+++ b/tests/workers/test_asyncio_queues.py
@@ -86,6 +86,37 @@ async def test_work_queue_enqueue_unique_deduplicates():
 
 
 @pytest.mark.asyncio
+async def test_work_queue_enqueue_unique_keeps_latest_payload():
+    '''Coalesced enqueue_unique calls resolve to the newest payload (latest wins).'''
+    q = AsyncioWorkQueue()
+    await q.enqueue_unique('mutable:k', {'v': 1}, priority=0)
+    await q.enqueue_unique('mutable:k', {'v': 2}, priority=0)
+    assert await q.dequeue(timeout=0.1) == ('mutable:k', {'v': 2})
+
+
+@pytest.mark.asyncio
+async def test_work_queue_enqueue_unique_no_overwrite_preserves_newer_payload():
+    '''A stale lock-retry re-enqueue (overwrite=False) must not clobber a newer payload.
+
+    Regression for the frozen-bundle bug: the dispatcher's lock-retry path re-enqueued
+    the payload it had dequeued, overwriting a newer "completed" render that arrived
+    while the lock was held — freezing the status message and skipping its delete.
+    '''
+    q = AsyncioWorkQueue()
+    await q.enqueue_unique('mutable:k', {'v': 'new'}, priority=0)
+    await q.enqueue_unique('mutable:k', {'v': 'stale'}, priority=0, overwrite=False)
+    assert await q.dequeue(timeout=0.1) == ('mutable:k', {'v': 'new'})
+
+
+@pytest.mark.asyncio
+async def test_work_queue_enqueue_unique_no_overwrite_restores_when_absent():
+    '''overwrite=False still stores the payload when none is pending (genuine retry).'''
+    q = AsyncioWorkQueue()
+    await q.enqueue_unique('mutable:k', {'v': 'retried'}, priority=0, overwrite=False)
+    assert await q.dequeue(timeout=0.1) == ('mutable:k', {'v': 'retried'})
+
+
+@pytest.mark.asyncio
 async def test_work_queue_dequeue_timeout_returns_none():
     '''dequeue returns None when the queue is empty and timeout expires.'''
     q = AsyncioWorkQueue()


### PR DESCRIPTION
## Symptom

A music request-bundle status message froze on a stale render and was never deleted. Repro from prod (guild `589886587953741824`, bundle `adc10523`): a 12-track album where the final track ("Excited Delirium") completed — it was added to the play queue — but the bundle message stayed stuck at:

> Processing … **11/12** media requests processed successfully, 0 failed
> Media request queued for download: "Excited Delirium"

It never advanced to "Completed 12/12" and never auto-deleted.

## Root cause

The dispatcher's per-bundle work queue coalesces rapid updates for the same `mutable:{key}` member, relying on the invariant *"the payload key always holds the latest content"* (`RedisDispatchQueue` docstring).

The lock-retry path in `MessageDispatcher._process_mutable` / `_remove_mutable` violates that invariant. On lock contention it **re-enqueues the payload it dequeued**, and `enqueue_unique` unconditionally `SET`s the payload. Since `dequeue` deletes the payload, a newer update that arrives between dequeue and re-enqueue can be clobbered by the stale re-`SET`:

1. Worker B holds the lock doing a slow Discord edit.
2. Worker A dequeues the next entry (GET + **DELETE** payload), then fails to acquire the lock.
3. The bot's final **"12/12 completed" + `delete_after`** update lands here (`SET` payload, `ZADD NX`).
4. Worker A re-enqueues → `SET` overwrites the fresh payload with the stale "11/12" one.

The completed render is lost; because the bundle is removed bot-side right after, no later update corrects it, and the `delete_after` that would have removed the message was on the dropped payload. Frozen forever.

Verified against the deployed dispatcher image (`discord_dispatch:0c74729f`, single pod / 4 workers, no restart during the incident). Logs show the bot **did** dispatch the final completed render at 18:50:10.678 — the dispatcher dropped it.

The in-process `AsyncioWorkQueue.enqueue_unique` had a worse sibling bug: it kept the **first** payload and dropped newer ones entirely.

## Fix

- `enqueue_unique` gains `overwrite: bool = True`. Fresh updates overwrite (latest wins); the lock-retry paths pass `overwrite=False`, which only restores the payload when none is stored (`SET NX` on Redis) — never clobbering a newer one.
- `AsyncioWorkQueue.enqueue_unique` now keeps the latest payload, matching Redis "latest wins" semantics.

## Tests

New regression tests across both queue backends and the dispatcher retry path:
- `tests/utils/test_dispatch_queue.py` — Redis overwrite default + `overwrite=False` no-clobber / restore-when-absent.
- `tests/workers/test_asyncio_queues.py` — latest-wins + `overwrite=False` no-clobber.
- `tests/cogs/test_message_dispatcher.py` — `_process_mutable` lock-retry re-enqueues with `overwrite=False`.

Full suite: 1235 passed; the 176 errors are all `pytest_postgresql.ExecutableMissingException` (no Postgres binary in my sandbox), unrelated to this change. Changed files lint 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)